### PR TITLE
changeTracker.p.js: line 502 - Remove extra paren

### DIFF
--- a/src/chrome/komodo/content/library/changeTracker.p.js
+++ b/src/chrome/komodo/content/library/changeTracker.p.js
@@ -499,7 +499,7 @@ this.ChangeTracker.prototype._createPanel = function(htmlFile, undoTextFunc) {
         panel.sizeTo(600, 400);
         fileSvc.deleteTempFile(htmlFile.path, true);
         undoButton.addEventListener("command", undoTextFunc, false);
-    }.bind(this));
+    }.bind(this);
     var panelHiddenFunc = function(event) {
         undoButton.removeEventListener("command", undoTextFunc, false);
         iframe.removeEventListener("load", iframeLoadedFunc, true);


### PR DESCRIPTION
It seems https://github.com/Komodo/KomodoEdit/commit/bd8fe75f70 left an extra paran in changeTracker.p.js causing compilation to fail.
