### PR TITLE
fix endless "INFO: _hit_from_elem_imports:: ie: lookup ('',) in => []" i...

### DIFF
--- a/src/udl/skel/PHP/pylib/lang_php.py
+++ b/src/udl/skel/PHP/pylib/lang_php.py
@@ -1071,9 +1071,9 @@ class PHPLangIntel(CitadelLangIntel, ParenStyleCalltipIntelMixin,
 
             # - extradirslib
             extra_dirs = self._extra_dirs_from_env(env)
-            for extra_dir in extra_dirs:
+            if extra_dirs:
                 libs.append( db.get_lang_lib("PHP", "extradirslib",
-                                             [extra_dir], "PHP") )
+                                             extra_dirs, "PHP") )
 
             # - inilib (i.e. dirs in the include_path in PHP.ini)
             include_dirs = [d for d in include_path


### PR DESCRIPTION
...n codeIntel for PHP

This is a fix for the issue described here:
http://community.activestate.com/node/10110#comment-26290
and here:
http://community.activestate.com/node/10419#comment-27216

When PHP-codeintel was doing a full scan on ALL possible imports without a lucky-hit (resulting in searching all files it has heard of, multiple times), this bug used to freeze the Application... on ... every ... keystroke!
