### PR TITLE
PEP8 way of Python code commenting. '#' -> '# '

### DIFF
--- a/src/languages/koPythonLanguage.p.py
+++ b/src/languages/koPythonLanguage.p.py
@@ -132,7 +132,7 @@ class KoPythonCommonLanguage(KoLanguageBase):
     defaultExtension = ".py"
     # XXX read url from some config file
     downloadURL = 'http://www.activestate.com/activepython'
-    commentDelimiterInfo = { "line": [ "#" ]  }
+    commentDelimiterInfo = { "line": [ "# " ]  }
     _indent_open_chars = ':{[('
     _lineup_open_chars = "([{" 
     _lineup_close_chars = ")]}"


### PR DESCRIPTION
PEP8 recommends to comment using # + space. While it is just a style guide, code quality tools like landscape.io raise style problems when not followed resulting in very poor score. Changing '#' to '# ' made my project ObjectPath (ca. 1500 lines) score better by 4% there.
