### PR TITLE
JavaScript and CoffeeScript keyword update

### DIFF
--- a/src/python-sitelib/langinfo_prog.py
+++ b/src/python-sitelib/langinfo_prog.py
@@ -223,7 +223,7 @@ class CoffeeScriptLangInfo(_JSLikeLangInfo):
                          'is', 'isnt',
                          'loop',
                          'no', 'not',
-                         'of', 'off', 'on', 'or',
+                         'of', 'off', 'on', 'or', 'own',
                          'then',
                          'unless', 'until',
                          'when',


### PR DESCRIPTION
I've been studying CoffeeScript and JavaScript a lot over the past few weeks, and from what I can surmise, the changes I made are entirely appropriate. I forgot to mention in the commit messages that I've removed the CoffeeScript keywords 'await' and 'defer' as they are part of another language called icedCoffeeScript, that has not officially been merged with CoffeeScript.
