### PR TITLE
codeintel2: Python: Fixes relative imports

### DIFF
--- a/src/codeintel/lib/codeintel2/tree_python.py
+++ b/src/codeintel/lib/codeintel2/tree_python.py
@@ -551,7 +551,11 @@ class PythonTreeEvaluator(TreeEvaluator):
             if module_name.startswith("."):
                 allow_parentdirlib = False
                 # Need a different curdirlib.
-                lookuppath = self.buf.path
+                if libs[0].name == "reldirlib":
+                    lookuppath = libs[0].dirs[0]
+                    module_name = module_name[1:]
+                else:
+                    lookuppath = self.buf.path
                 while module_name.startswith("."):
                     lookuppath = dirname(lookuppath)
                     module_name = module_name[1:]


### PR DESCRIPTION
Relative improts where always based on the main buffer's path.
Instead, use current relative path (if there is one) for relative
imports.

Fixes the case where a module `module.first` imports `module.first.some`
by using relative import `import .some` and the current buffer's path
is not in `module/first`.