### PR TITLE
Fixed #498

### DIFF
--- a/src/chrome/komodo/content/pref/pref-codeintel.p.xul
+++ b/src/chrome/komodo/content/pref/pref-codeintel.p.xul
@@ -89,7 +89,7 @@
             <separator class="thin"/>
             <checkbox id="codeintel_completion_auto_fillups_enabled"
                       label="&enableAutocompleteFillUpCharacters.label;"
-                      pref="true" prefattribute="checked"/>
+                      pref="true"/>
             <description style="margin-left: 27px;">
                 &codeIntelAutocompleteFillUpCharacters.description;
             </description>


### PR DESCRIPTION
I've tested it with a clean profile (`export KOMODO_USERDATADIR="/ko/temp"`) and it works fine. Fill-up is disabled by default and doesn't work until the user will enable it in Preferences (checkbox would be unchecked by default)