### PR TITLE
Update html5.dtd

### DIFF
--- a/contrib/catalogs/html5/html5.dtd
+++ b/contrib/catalogs/html5/html5.dtd
@@ -72,7 +72,7 @@
 <!ENTITY % Text "CDATA">
     <!-- used for titles etc. -->
 
-<!ENTITY % FrameTarget "(_blank | _parent | _self | _top">
+<!ENTITY % FrameTarget "(_blank | _parent | _self | _top)">
     <!-- render in this frame -->
 
 <!ENTITY % Length "CDATA">


### PR DESCRIPTION
Fix a syntactical error in the FrameTarget entity that causes breakage in the tag/attribute completion for any element using that entity for attributes following references to it