### PR TITLE
Update loose.dtd

### DIFF
--- a/contrib/catalogs/sgml-lib/REC-html401-19991224/loose.dtd
+++ b/contrib/catalogs/sgml-lib/REC-html401-19991224/loose.dtd
@@ -123,7 +123,7 @@
 
 <!ENTITY % StyleSheet "CDATA" -- style sheet data -->
 
-<!ENTITY % FrameTarget "(_blank | _parent | _self | _top">
+<!ENTITY % FrameTarget "(_blank | _parent | _self | _top)">
     <!-- render in this frame -->
 
 


### PR DESCRIPTION
Fix a syntactical error in the FrameTarget entity that causes breakage in the tag/attribute completion for any element using that entity for attributes following references to it