### PR TITLE
Update xhtml1-transitional.dtd

### DIFF
--- a/contrib/catalogs/sgml-lib/REC-xhtml1-20020801/xhtml1-transitional.dtd
+++ b/contrib/catalogs/sgml-lib/REC-xhtml1-20020801/xhtml1-transitional.dtd
@@ -85,7 +85,7 @@
 <!ENTITY % Text "CDATA">
     <!-- used for titles etc. -->
 
-<!ENTITY % FrameTarget "(_blank | _parent | _self | _top">
+<!ENTITY % FrameTarget "(_blank | _parent | _self | _top)">
     <!-- render in this frame -->
 
 <!ENTITY % Length "CDATA">


### PR DESCRIPTION
Fix a syntactical error in the FrameTarget entity that causes breakage in the tag/attribute completion for any element using that entity for attributes following references to it