### PR TITLE
1038: stop assuming all multi-lang files are markup-based

### DIFF
--- a/src/lint/koHTMLLinter.py
+++ b/src/lint/koHTMLLinter.py
@@ -402,7 +402,13 @@ class _CommonHTMLLinter(object):
         htmlAllowedNames = ("HTML", "HTML5", "CSS", "JavaScript", "XML")
         currState = self._IN_M
         prevText = ""
-        prevLanguageFamily = "M"
+        startLang = languageNamesAtTransitionPoints[0]
+        if startLang in htmlAllowedNames:
+            prevLanguageFamily = {"JavaScript":"CSL", "CSS":"CSS"}.get(startLang, "M")
+        else:
+            #XXX: One day, distinguish SSL from TPL
+            prevLanguageFamily = "SSL"
+            
         currLineNum = 1
         js_func_num = 0
         js_func_name_prefix = "__kof_"
@@ -521,7 +527,7 @@ class _CommonHTMLLinter(object):
                             bytesByLang.replace_ending_white_space(name, "function %s%d() {" % (js_func_name_prefix, js_func_num), currLineNum)
                             self._emittedCodeLineNumbers.add(currLineNum)
                             currState |= self._IN_JS_FUNCTION_DEF
-                        else:
+                        elif prevLanguageFamily == "M":
                             log.debug("Hit weird block of JS (%s) starting with HTML %s", self._trim(currText), self._trim(prevText))
                             currState |= self._IN_JS_SQUELCH
                         m = self._starts_with_cdata_re.match(currText)


### PR DESCRIPTION
Sample input to test this:
if ("missing close-paren should be flagged" {
  let x = y;
  <% if "ruby complains about bad indentation " %>
  alert('foo")
      <% end %>
}

You should see a ruby indentation warning, but no JS error messages.  Apply the patch,
and JS problems should appear.