### PR TITLE
Fixed #622: make search string red if regex is enabled and it's invalid

### DIFF
--- a/src/chrome/komodo/content/find/findbar.xml
+++ b/src/chrome/komodo/content/find/findbar.xml
@@ -268,7 +268,22 @@
       <method name="onInput">
         <body>
         <![CDATA[
-          this.controller.search(this.text);
+          for each (var clazz in Array.slice(this.classList)) {
+            if (/^ko-findbar-status-/.test(clazz)) {
+              this.classList.remove(clazz);
+            }
+          }
+          if (!this.patternType == "FOT_REGEX_PYTHON") {
+            this.controller.search(this.text);
+            return;
+          }
+          try {
+            this.classList.add('ko-findbar-status'); // reset class to normal
+            var regex = new RegExp(this.text);
+            this.controller.search(this.text);
+          } catch (e) {
+            this.classList.add('ko-findbar-status-invalid-regex');
+          }
         ]]>
         </body>
       </method>

--- a/src/chrome/komodo/skin/bindings/findbar.css
+++ b/src/chrome/komodo/skin/bindings/findbar.css
@@ -40,6 +40,11 @@ ko-findbar.ko-findbar-status-not-found .ko-findbar-textbox > .autocomplete-textb
   color: white;
 }
 
+ko-findbar.ko-findbar-status-invalid-regex .ko-findbar-textbox >
+.autocomplete-textbox-container {
+    color: rgba(255, 64, 64, 0.8);
+}
+
 ko-findbar .ko-findbar-status {
   visibility:  collapse;
   -moz-box-pack: start;


### PR DESCRIPTION
Fixed #622.
Now it looks like on the screenshot:
![pic](http://i.imgur.com/zIymaFd.png)