### PR TITLE
upgrade: ignore errors (when asked) for source directories that do not exist

### DIFF
--- a/src/components/koInitService.p.py
+++ b/src/components/koInitService.p.py
@@ -211,8 +211,10 @@ def _copy(src, dst, overwriteExistingFiles=True, ignoreErrors=False,
                               % (repr(s), repr(d), str(why)))
                     
         elif not usingWildcards:
-            raise OSError("Source file %s does not exist" % repr(srcFile))
-
+            if ignoreErrors:
+                log.warn("Source file %r does not exist", srcFile)
+            else:
+                raise OSError("Source file %r does not exist" % srcFile)
 
 def _rmtreeOnError(rmFunction, filePath, excInfo):
     if excInfo[0] == OSError:


### PR DESCRIPTION
During upgrade (from 9.3 to 10.0), my Linux machine had a barely used Komodo 9.3 profile, and as such did not have the *~/.komodoide/9.3/XRE/extensions* folder, which caused the upgradeUserSettings function to fail with this error:
```
[2016-06-17 09:05:56,555] [ERROR] koInitService: upgradeUserSettings
Traceback (most recent call last):
  File "/home/toddw/install/Komodo-IDE-10/lib/mozilla/components/koInitService.py", line 1494, in upgradeUserSettings
    self._upgradeUserDataDirFiles()
  File "/home/toddw/install/Komodo-IDE-10/lib/mozilla/components/koInitService.py", line 1475, in _upgradeUserDataDirFiles
    ignoreErrors=True)
  File "/home/toddw/install/Komodo-IDE-10/lib/mozilla/components/koInitService.py", line 184, in _copy
    raise OSError("Source file %r does not exist" % srcFile)
OSError: Source file u'/home/toddw/tmp/koprofile/9.3/XRE/extensions' does not exist
```

This patch catches this error when ignoreExceptions is set (which the *copyUserSettings* function is currently doing).
