### PR TITLE
Reduce padding for Fitts' law

### DIFF
--- a/src/chrome/komodo/skin/global/chromeless.less
+++ b/src/chrome/komodo/skin/global/chromeless.less
@@ -87,7 +87,7 @@ dialog:not([_hidechrome="true"]):not(.embedded)
     #toolbox_main
     {
         /* For some reason windows seems to eat up approx 6 pixels of the window top */
-        padding-top: 10px;
+        padding-top: 8px;
     }
 }
 


### PR DESCRIPTION
The 10px padding on the menu is slightly too much.  When you move the cursor to the top of the screen, the menu is 2px too low to click on, so you have to move back down slightly.  This change lowers the padding so that you can throw your mouse cursor to the top of the screen and click a menu immediately.
