### PR TITLE
Linter: CSS: fixed #1823 (incorrect word for SASS linter popup)

### DIFF
--- a/src/lint/koCSSExLinter.py
+++ b/src/lint/koCSSExLinter.py
@@ -143,7 +143,7 @@ class KoSCSSCommonLinter(KoCommonCSSLintCode):
                 else:
                     severity = koLintResult.SEV_WARNING
                     msg = prevLine
-                desc = "scss: " + msg
+                desc = self.cmd + ": " + msg
                 koLintResult.createAddResult(results, textlines, severity, lineNo, desc)
             else:
                 prevLine = line


### PR DESCRIPTION
Signed-off-by: Defman21 <i@defman.me>