### PR TITLE
Linter: SCSS: detect rbenv and use it's sh file, otherwise use /path/…

### DIFF
--- a/src/lint/koCSSExLinter.py
+++ b/src/lint/koCSSExLinter.py
@@ -115,7 +115,11 @@ class KoSCSSCommonLinter(KoCommonCSSLintCode):
             fout.write(text)
             fout.close()
             textlines = text.splitlines()
-            cmd = [rubyPath, scssPath, "-c", tmpfilename]
+            try:
+                which.which("rbenv")
+                cmd = [scssPath, "-c", tmpfilename]
+            except which.WhichError:
+                cmd = [rubyPath, scssPath, "-c", tmpfilename]
             #koLintResult.insertNiceness(cmd)
             cwd = request.cwd or None
             # We only need the stderr result.


### PR DESCRIPTION
…to/ruby /path/to/sass command; fixed #1819

Signed-off-by: Defman21 <i@defman.me>