### PR TITLE
dont show color swatch on less and scss vars, fixes #1920

### DIFF
--- a/src/chrome/komodo/content/hyperlinks/csscolorpicker.js
+++ b/src/chrome/komodo/content/hyperlinks/csscolorpicker.js
@@ -264,9 +264,11 @@ ko.hyperlinks.ColorPickerHandler.prototype.show = function(
     var start = scimoz.wordStartPosition(position, true);
     var end = scimoz.wordEndPosition(position, true);
     var hyperlink;
+    var isNotVar = /[@\$]/.test(scimoz.getWCharAt(start - 1).toString()) ? false : true; // if it's a less or scss var don't show color swatch
+    
     // Check if it's a named css color, else try the regex matching.
     if ((start < end) &&
-        (ko.hyperlinks.ColorPickerHandler.named_css_colors.indexOf(scimoz.getTextRange(start, end).toLowerCase()) >= 0)) {
+        (ko.hyperlinks.ColorPickerHandler.named_css_colors.indexOf(scimoz.getTextRange(start, end).toLowerCase()) >= 0) && isNotVar) {
         var prefs = Components.classes["@activestate.com/koPrefService;1"].
                         getService(Components.interfaces.koIPrefService).prefs;
         var languages = prefs.getString('hyperlinksColorpickerEnabled').split(",");


### PR DESCRIPTION
Added a fix for #1920 a simple check if it's not a less or sass/scss var.