### PR TITLE
Locale: dedent -> unindent; fixed #991

### DIFF
--- a/src/chrome/komodo/locale/en-US/keybindings/keybindings.dtd
+++ b/src/chrome/komodo/locale/en-US/keybindings/keybindings.dtd
@@ -122,7 +122,7 @@
 <!ENTITY editorViSelectToTopOfDocument.desc "Editor: Vi: Select to Top of Document">
 <!ENTITY editorViSetRegister.desc "Editor: Vi: Set Register">
 <!ENTITY editorViStartChangeTextOperation.desc "Editor: Vi: Start Change Text Operation">
-<!ENTITY editorViStartDedentTextOperation.desc "Editor: Vi: Start Dedent Text Operation">
+<!ENTITY editorViStartDedentTextOperation.desc "Editor: Vi: Start Unindent Text Operation">
 <!ENTITY editorViStartDeleteTextOperation.desc "Editor: Vi: Start Delete Text Operation">
 <!ENTITY editorViStartIndentTextOperation.desc "Editor: Vi: Start Indent Text Operation">
 <!ENTITY editorViStartYankTextOperation.desc "Editor: Vi: Start Yank Text Operation">

--- a/src/chrome/komodo/locale/en-US/komodo.dtd
+++ b/src/chrome/komodo/locale/en-US/komodo.dtd
@@ -100,7 +100,7 @@
 <!ENTITY cutButton.accesskey "T">
 <!ENTITY decreaseFont.accesskey "D">
 <!ENTITY decreaseFont.label "Decrease Font Size">
-<!ENTITY decreaseLineIndent.label "Dedent">
+<!ENTITY decreaseLineIndent.label "Unindent">
 <!ENTITY delete.label "Delete">
 <!ENTITY deleteBlankLines.desc "Editor: Delete Blank Lines">
 <!ENTITY edit.label "Edit">

--- a/src/chrome/komodo/locale/en-US/pref/pref.dtd
+++ b/src/chrome/komodo/locale/en-US/pref/pref.dtd
@@ -185,7 +185,7 @@
 <!ENTITY dDayOfTheMonth0131.label "&#37;d : day of the month [01,31]">
 <!ENTITY debuggerCallingLineBackgroundColor.label "Debugger calling line background color">
 <!ENTITY debuggerCurrentLineBackgroundColor.label "Debugger current line background color">
-<!ENTITY dedentOnColon.label "Dedent line after colon (Python)">
+<!ENTITY dedentOnColon.label "Unindent line after colon (Python)">
 <!ENTITY defaultConnectionTimeout.label "Default Connection Timeout">
 <!ENTITY defaultEditorEncoding.label "Default Editor Encoding">
 <!ENTITY defaultHTMLDocumentType.label "Default HTML Document Type">


### PR DESCRIPTION
Signed-off-by: Defman21 <i@defman.me>

I did not rename any code-specific identifiers though. They are still dedent. Only UX :)