### PR TITLE
Notify: handle Ctrl+K exception in Console widget

### DIFF
--- a/src/modules/notify/content/sdk/notify.js
+++ b/src/modules/notify/content/sdk/notify.js
@@ -619,6 +619,16 @@
     
     this.hideNotification = (notif, animate) =>
     {
+        if (typeof notif === "undefined") {
+            try {
+                throw new Typeerror(); // save tracelog
+            } catch (e) {
+                log.debug("nofif is undefined");
+                log.debug(e.stack);
+                return;
+            }
+        }
+        
         log.debug("Hiding Notification: " + notif.opts.id);
         
         if ( ! notif)


### PR DESCRIPTION
this should handle any errors when notif is undefined

Signed-off-by: Defman21 <i@defman.me>

fixed #2120 