### PR TITLE
Notify: debug notification id only when calling hideNotification with…

### DIFF
--- a/src/modules/notify/content/sdk/notify.js
+++ b/src/modules/notify/content/sdk/notify.js
@@ -619,7 +619,6 @@
     
     this.hideNotification = (notif, animate) =>
     {
-        log.debug("Hiding Notification: " + notif.opts.id);
         
         if ( ! notif)
         {
@@ -632,6 +631,8 @@
             }
             return;
         }
+        
+        log.debug("Hiding Notification: " + notif.opts.id);
         
         var panel = queue[notif.opts.from].activePanel;
         if (panel && queue[notif.opts.from].timeout) timers.clearTimeout(queue[notif.opts.from].timeout);


### PR DESCRIPTION
… arguments

hideNotification could be called without arguments at all to hide all of them (for example, `P_NOW` notifications).

fixed #2120 

Signed-off-by: Defman21 <i@defman.me>