### PR TITLE
Console: fixed autocomplete popup being under some elements

### DIFF
--- a/src/modules/console/content/less/console.less
+++ b/src/modules/console/content/less/console.less
@@ -294,6 +294,7 @@ a:hover {
     position: absolute;
     display: none;
     z-index: 9999;
+    height: 80%;
     max-height: 200px;
     overflow: hidden;
     overflow-y: auto;


### PR DESCRIPTION
It's now always in the area of the console widget (80% height of it, but still 200px maximum)

Signed-off-by: Defman21 <i@defman.me>

fixed #1315