### PR TITLE
Commando: don't show the expand tip if allowExpand of the first item …

### DIFF
--- a/src/modules/commando/content/sdk/commando.js
+++ b/src/modules/commando/content/sdk/commando.js
@@ -471,7 +471,8 @@
             c.renderResult({
                 id: "",
                 name: "No Results",
-                classList: "no-result-msg non-interact"
+                classList: "no-result-msg non-interact",
+                allowExpand: false
             }, uuid);
         }
 
@@ -2055,6 +2056,8 @@
 
     this.tip = function(tipMessage, type = "normal")
     {
+        let selected = this.getSelectedResult();
+
         if ( ! tipMessage && local.quickSearch)
         {
             var bindLabel = keybinds.getKeybindFromCommand("cmd_showCommando");
@@ -2062,11 +2065,14 @@
             if (bindLabel != "")
                 tipMessage = "TIP: Press " + bindLabel + " to quickly Go To Anything.";
         }
-        
+
+        if (!tipMessage && selected.allowExpand !== false) {
+            tipMessage = 'TIP: Hit the right arrow key to "expand" your selection';
+        }
+
         // todo: Use localized database of tips
         elem("tip").attr("tip-type", type);
-        elem("tip").text(tipMessage ||
-                             'TIP: Hit the right arrow key to "expand" your selection');
+        elem("tip").text(tipMessage || "");
         
         c.reloadTip();
     }

--- a/src/modules/scope_combined/content/everything.js
+++ b/src/modules/scope_combined/content/everything.js
@@ -82,6 +82,7 @@
                 accesskey: scope.accesskey,
                 description: scope.description || "",
                 icon: icon,
+                allowExpand: false,
                 scope: "scope-combined",
                 data: {
                     isScope: true


### PR DESCRIPTION
…in a scope set to false, fixed #2505;

Don't allow to expand No Results item and items in the Everything scope (no handler for that were in the code)

Signed-off-by: Defman21 <i@defman.me>