### PR TITLE
Added an id to Hightlight Variable groupbox

### DIFF
--- a/src/chrome/komodo/content/pref/pref-editsmart.xul
+++ b/src/chrome/komodo/content/pref/pref-editsmart.xul
@@ -436,7 +436,7 @@
                       prefstring="editRestoreFoldPoints" prefattribute="checked"/>
         </groupbox>
 
-        <groupbox class="load-context-check" showIfLoadContext="global">
+        <groupbox class="load-context-check" showIfLoadContext="global" id="highlightvariable_groupbox">
             <caption label="&highlightVariable.label;"/>
             <checkbox label="&highlightVariableMouse.label;" pref="true"
                       preftype="boolean"


### PR DESCRIPTION
It has an id in the IDE, but not in the Edit version (so I couldn't inject Xemmet prefs in the Edit version)