### PR TITLE
Remove typo?

### DIFF
--- a/src/chrome/komodo/skin/codeintel.p.css
+++ b/src/chrome/komodo/skin/codeintel.p.css
@@ -1,4 +1,3 @@
-    width: 14px;
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  * 


### PR DESCRIPTION
I suppose this might be "included" as part of a bigger template but from running Komodo and looking at the startup logs it seems like this is also dynamically interpreted as a syntax error. I assume its not actually doing anything due to this so I think it should be removed.