### PR TITLE
CodeIntel2 Optimizations & Corruption Call Fix

### DIFF
--- a/src/codeintel/lib/codeintel2/citadel.py
+++ b/src/codeintel/lib/codeintel2/citadel.py
@@ -479,7 +479,7 @@ class ImportHandler:
     # (use Foo::Bar;), '/' for Ruby, etc. Must be set for each language.
     sep = None
     
-    def find_importables_in_dir(self, dir):
+    def find_importables_in_dir(self, dir, env=None):
         """Return a mapping of
             import-name -> (path, subdir-import-name, is-dir-import)
         for all possible importable "things" in the given dir. Each part

--- a/src/codeintel/lib/codeintel2/database/langlibbase.py
+++ b/src/codeintel/lib/codeintel2/database/langlibbase.py
@@ -41,8 +41,9 @@ class LangDirsLibBase(object):
             # TODO: i18n w/ PluralForms
             msg = "Scanning %r directories" % (len(dirs),)
             if len(dirs) == 1:
-                for single_dir in dirs:
-                    msg = "Scanning one directory: %s" % single_dir;
+                msg = "Scanning one directory"
+                # for single_dir in dirs:
+                #     msg = "Scanning one directory: %s" % single_dir;
             reporter.onScanStarted(msg, dirs)
 
         log.debug("ensure_all_dirs_scanned: scanning %r directories",

--- a/src/codeintel/lib/codeintel2/database/langlibbase.py
+++ b/src/codeintel/lib/codeintel2/database/langlibbase.py
@@ -41,7 +41,8 @@ class LangDirsLibBase(object):
             # TODO: i18n w/ PluralForms
             msg = "Scanning %r directories" % (len(dirs),)
             if len(dirs) == 1:
-                msg = "Scanning one directory"
+                for single_dir in dirs:
+                    msg = "Scanning one directory: %s" % single_dir;
             reporter.onScanStarted(msg, dirs)
 
         log.debug("ensure_all_dirs_scanned: scanning %r directories",

--- a/src/codeintel/lib/codeintel2/database/langlibbase.py
+++ b/src/codeintel/lib/codeintel2/database/langlibbase.py
@@ -42,8 +42,6 @@ class LangDirsLibBase(object):
             msg = "Scanning %r directories" % (len(dirs),)
             if len(dirs) == 1:
                 msg = "Scanning one directory"
-                # for single_dir in dirs:
-                #     msg = "Scanning one directory: %s" % single_dir;
             reporter.onScanStarted(msg, dirs)
 
         log.debug("ensure_all_dirs_scanned: scanning %r directories",

--- a/src/codeintel/lib/codeintel2/database/multilanglib.py
+++ b/src/codeintel/lib/codeintel2/database/multilanglib.py
@@ -680,7 +680,8 @@ class MultiLangZone(LangZone):
                 except KeyError, ex:
                     self.db.corruption("MultiLangZone.get_buf_data",
                         "could not find lang `%s' or blob `%s' for buffer `%s'"\
-                            % (lang, blobname, buf.path))
+                            % (lang, blobname, buf.path),
+                        "recover")
                     self.remove_buf_data(buf)
                     raise NotFoundInDatabase(
                         "`%s' buffer %s `%s' blob not found in database"

--- a/src/codeintel/lib/codeintel2/lang_perl.py
+++ b/src/codeintel/lib/codeintel2/lang_perl.py
@@ -1394,7 +1394,7 @@ class PerlImportHandler(ImportHandler):
                 #    extension: need to grow filetype-from-content smarts.
                 files.append(path)
 
-    def find_importables_in_dir(self, dir):
+    def find_importables_in_dir(self, dir, env=None):
         """See citadel.py::ImportHandler.find_importables_in_dir() for
         details.
 

--- a/src/codeintel/lib/codeintel2/lang_python.py
+++ b/src/codeintel/lib/codeintel2/lang_python.py
@@ -1146,7 +1146,7 @@ class PythonImportHandler(ImportHandler):
                 if suffix[0] == '.' and mod_type  == imp.C_EXTENSION:
                     yield suffix
 
-    def find_importables_in_dir(self, imp_dir):
+    def find_importables_in_dir(self, imp_dir, env=None):
         """See citadel.py::ImportHandler.find_importables_in_dir() for
         details.
 

--- a/src/codeintel/lib/codeintel2/lang_ruby.py
+++ b/src/codeintel/lib/codeintel2/lang_ruby.py
@@ -1546,7 +1546,7 @@ class RubyImportHandler(ImportHandler):
                 #    extension: need to grow filetype-from-content smarts.
                 files.append(path)
 
-    def find_importables_in_dir(self, dir):
+    def find_importables_in_dir(self, dir, env=None):
         """See citadel.py::ImportHandler.find_importables_in_dir() for
         details.
 

--- a/src/codeintel/lib/codeintel2/util.py
+++ b/src/codeintel/lib/codeintel2/util.py
@@ -672,18 +672,19 @@ def walk2(top, topdown=True, onerror=None, followlinks=False,
             if ondecodeerror is not None:
                 ondecodeerror(err)
 
+    # Check for skipped directories
+    for name in dirs:
+        if name in dir_names_to_skip:
+            dirs.remove(name)
+            continue
+        if join(top, name) in exclude_dirs:
+            dirs.remove(name)
+            continue
+
     if topdown:
         yield top, dirs, nondirs
     for name in dirs:
         path = join(top, name)
-
-        # Check if directory is skipped
-        if path in exclude_dirs:
-            dirs.remove(name)
-            continue
-        if name in dir_names_to_skip:
-            dirs.remove(name)
-            continue
 
         # Walk this directory
         if followlinks or not islink(path):

--- a/src/codeintel/src/komodo/koCodeIntel.py
+++ b/src/codeintel/src/komodo/koCodeIntel.py
@@ -1936,6 +1936,7 @@ class KoCodeIntelEnvironment(object):
             "codeintel_scan_files_in_project": T(getter=get_bool),
             "codeintel_max_recursive_dir_depth": T(getter=get_int),
             "codeintel_selected_catalogs": T(getter=get_json_or_eval),
+            "import_exclude_matches": T(),
             "defaultHTMLDecl": T(),
             "defaultHTMLNamespace": T(),
             "defaultHTML5Decl": T(),

--- a/src/udl/skel/PHP/pylib/lang_php.py
+++ b/src/udl/skel/PHP/pylib/lang_php.py
@@ -108,6 +108,8 @@ def _walk_php_symbols(elem, _prefix=None):
 class PHPLangIntel(CitadelLangIntel, ParenStyleCalltipIntelMixin,
                    ProgLangTriggerIntelMixin):
     lang = lang
+    importExcludeMatchesPrefName = "import_exclude_matches"
+    excludePathsPrefName = "phpExcludePaths"
 
     # Used by ProgLangTriggerIntelMixin.preceding_trg_from_pos()
     trg_chars = tuple('$>:(,@"\' \\')
@@ -1011,14 +1013,14 @@ class PHPLangIntel(CitadelLangIntel, ParenStyleCalltipIntelMixin,
             if not pref: continue
             extra_dirs.update(d.strip() for d in pref.split(os.pathsep)
                               if exists(d.strip()))
-        for pref in env.get_all_prefs("phpExcludePaths"):
+        for pref in env.get_all_prefs(self.excludePathsPrefName):
             if not pref: continue
             exclude_dirs.update(d.strip() for d in pref.split(os.pathsep)
                                 if exists(d.strip()))
 
         # Get excluded names
         excluded_dir_names = [];
-        for excludes_pref in env.get_all_prefs("import_exclude_matches"):
+        for excludes_pref in env.get_all_prefs(self.importExcludeMatchesPrefName):
             if excludes_pref:
                 for exclude_item in excludes_pref.split(";"):
                     # Exclude anything with a star or a dot (likely a file)
@@ -1048,9 +1050,9 @@ class PHPLangIntel(CitadelLangIntel, ParenStyleCalltipIntelMixin,
             env.add_pref_observer("php", self._invalidate_cache)
             env.add_pref_observer("phpExtraPaths",
                 self._invalidate_cache_and_rescan_extra_dirs)
-            env.add_pref_observer("phpExcludePaths",
+            env.add_pref_observer(self.excludePathsPrefName,
                 self._invalidate_cache_and_rescan_extra_dirs)
-            env.add_pref_observer("import_exclude_matches",
+            env.add_pref_observer(self.importExcludeMatchesPrefName,
                 self._invalidate_cache_and_rescan_extra_dirs)
             env.add_pref_observer("phpConfigFile",
                                   self._invalidate_cache)
@@ -1103,14 +1105,14 @@ class PHPLangIntel(CitadelLangIntel, ParenStyleCalltipIntelMixin,
 
                 # Check for excludes
                 exclude_dirs = set()
-                for pref in env.get_all_prefs("phpExcludePaths"):
+                for pref in env.get_all_prefs(self.excludePathsPrefName):
                     if not pref: continue
                     exclude_dirs.update(d.strip() for d in pref.split(os.pathsep)
                         if exists(d.strip()))
 
                 # Get excluded names
                 excluded_dir_names = set()
-                for excludes_pref in env.get_all_prefs("import_exclude_matches"):
+                for excludes_pref in env.get_all_prefs(self.importExcludeMatchesPrefName):
                     if excludes_pref:
                         for exclude_item in excludes_pref.split(";"):
                             # Exclude anything with a star or a dot (likely a file)


### PR DESCRIPTION
- Add missing db.corruption param to multilanglib.py. Addresses Komodo/KomodoEdit#2228
- Exclude directories sooner to reduce unnecessary filesystem calls and later filtering.
- Update PHP, Javascript, and CSS to better respect excludes.  Addresses #3591
  - Other languages might need the same treatment.  I only worked on the primary ones I use.