### PR TITLE
Minor Fixes from Error Log

### DIFF
--- a/src/chrome/komodo/content/komodo.p.js
+++ b/src/chrome/komodo/content/komodo.p.js
@@ -474,7 +474,8 @@ function onloadDelay() {
             xtk.domutils.fireEvent(window, "komodo-post-startup");
             require("ko/profiler").save("event-post-startup");
             require("ko/profiler").stop("event-post-startup");
-            authenticateUser(); 
+            // Seems to a leftover from IDE.  There is no such function.
+            // authenticateUser();
         }, 2500);
 
 // #if BUILD_FLAVOUR == "dev"

--- a/src/chrome/komodo/content/komodo.p.js
+++ b/src/chrome/komodo/content/komodo.p.js
@@ -474,8 +474,6 @@ function onloadDelay() {
             xtk.domutils.fireEvent(window, "komodo-post-startup");
             require("ko/profiler").save("event-post-startup");
             require("ko/profiler").stop("event-post-startup");
-            // Seems to a leftover from IDE.  There is no such function.
-            // authenticateUser();
         }, 2500);
 
 // #if BUILD_FLAVOUR == "dev"

--- a/src/chrome/komodo/skin/images/toolbox/command.svg
+++ b/src/chrome/komodo/skin/images/toolbox/command.svg
@@ -57,17 +57,6 @@
   </metadata>
   <defs
      id="defs12" />
-  <g
-     id="g4">
-    <line
-       style="stroke:#449fdb;stroke-width:1"
-       id="line6"
-       opacity=""
-       y2="0"
-       x2="0"
-       y1="0"
-       x1="0" />
-  </g>
   <path
      inkscape:connector-curvature="0"
      style="fill:#9e9e9e;fill-opacity:1;stroke-width:0.82907736"


### PR DESCRIPTION
- Remove undefined function call resulting in:
```
[ERROR] console-logger: ReferenceError: authenticateUser is not defined (2) in chrome://komodo/content/komodo.js:477
```
- Remove non-visible SVG element resulting in this error:
```
[WARNING] console-logger: Error in parsing value for 'opacity'.  Declaration dropped. (1) in chrome://komodo/skin/images/toolbox/command.svg:0
```