### PR TITLE
HTML, JavaScript, And CSS Code Completions

### DIFF
--- a/contrib/catalogs/html5/html5.dtd
+++ b/contrib/catalogs/html5/html5.dtd
@@ -86,6 +86,9 @@
 
 <!ENTITY % Boolean "(true|false)">
 
+<!ENTITY % OlType "(1 | a | A | i | I)">
+    <!-- ol type attribute -->
+
 <!-- these are used for image maps -->
 
 <!ENTITY % Shape "(rect|circle|poly|default)">
@@ -542,6 +545,7 @@
 <!ELEMENT ol (li)+>
 <!ATTLIST ol
   %attrs;
+  type        %OlType;        #IMPLIED
   start       %Number;       #IMPLIED
   <!-- HTML 5 attributes -->
   reversed    (reversed)     #IMPLIED

--- a/contrib/catalogs/html5/html5.dtd
+++ b/contrib/catalogs/html5/html5.dtd
@@ -882,7 +882,7 @@
   onchange    %Script;       #IMPLIED
   accept      %ContentTypes; #IMPLIED
   <!-- HTML 5 attributes -->
-  autocomplete  (on|off)          #IMPLIED
+  autocomplete  (on|off|name|honorific-prefix|given-name|additional-name|family-name|honorific-suffix|nickname|email|username|new-password|current-password|organization-title|organization|street-address|address-line1|address-line2|address-line3|address-level4|address-level3|address-level2|address-level1|country|country-name|postal-code|cc-name|cc-given-name|cc-additional-name|cc-family-name|cc-number|cc-exp|cc-exp-month|cc-exp-year|cc-csc|cc-type|transaction-currency|transaction-amount|language|bday|bday-day|bday-month|bday-year|sex|tel|tel-country-code|tel-national|tel-area-code|tel-local|tel-extension|impp|url|photo)          #IMPLIED
   autofocus     CDATA          #IMPLIED
   form          CDATA          #IMPLIED
   formaction    %URI;          #IMPLIED

--- a/src/codeintel/lib/codeintel2/constants_css3.py
+++ b/src/codeintel/lib/codeintel2/constants_css3.py
@@ -36,6 +36,23 @@ CSS_PSEUDO_CLASS_NAMES = """
     before
     after
     not(
+    default
+    any-link
+    fullscreen
+    indeterminate
+    in-range
+    invalid
+    left
+    optional
+    out-of-range
+    read-only
+    read-write
+    required
+    right
+    scope
+    valid
+    is(
+    dir(
 """.split()
 
 

--- a/src/codeintel/lib/codeintel2/css_linter.py
+++ b/src/codeintel/lib/codeintel2/css_linter.py
@@ -235,6 +235,8 @@ class _CSSParser(object):
             "nth-last-child",
             "nth-of-type",
             "nth-last-of-type",
+            "is",
+            "dir"
             ]
         self._structural_pseudo_classes_no_args = [
             "root",
@@ -245,6 +247,21 @@ class _CSSParser(object):
             "first-of-type",
             "last-of-type",
             "only-of-type",
+            "default",
+            "any-link",
+            "fullscreen",
+            "indeterminate",
+            "in-range",
+            "invalid",
+            "left",
+            "optional",
+            "out-of-range",
+            "read-only",
+            "read-write",
+            "required",
+            "right",
+            "scope",
+            "valid",
             ]
         self._structural_pseudo_classes_other = [
             "not",

--- a/src/codeintel/lib/codeintel2/stdlibs/javascript.cix
+++ b/src/codeintel/lib/codeintel2/stdlibs/javascript.cix
@@ -1137,6 +1137,11 @@
         <variable citdl="DOMString" doc="Language code defined in RFC 1766. See the lang attribute&#xA;definition in HTML 4.01." name="lang" />
         <variable citdl="DOMString" doc="Specifies the base direction of directionally neutral text&#xA;and the directionality of tables. See the dir attribute&#xA;definition in HTML 4.01." name="dir" />
         <variable citdl="DOMString" doc="The class attribute of the element. This attribute has been&#xA;renamed due to conflicts with the &quot;class&quot; keyword exposed by&#xA;many languages." name="className" />
+        <variable citdl="DOMString" doc="Is a DOMString, where a value of &quot;true&quot; means the element is editable and a value of &quot;false&quot; means it isn't." name="contentEditable" />
+        <variable citdl="Boolean" doc="Returns a Boolean that indicates whether or not the content of the element can be edited." name="isContentEditable" />
+        <variable citdl="DOMStringMap" doc="Returns a DOMStringMap with which script can read and write the element's custom data attributes (data-*)." name="dataset" />
+        <variable citdl="DOMString" doc="Is a DOMString, reflecting the dir global attribute, representing the directionality of the element. Possible values are &quot;ltr&quot;, &quot;rtl&quot;, and &quot;auto&quot;." name="dir" />
+        <variable citdl="Boolean" doc="Is a Boolean indicating if the element is hidden or not." name="hidden" />
       </scope>
       <scope classrefs="HTMLElement" doc="Root of an HTML document. See the HTML element definition in&#xA;HTML 4.01." ilk="class" name="HTMLHtmlElement">
         <variable citdl="DOMString" doc="Version information about the document&apos;s DTD. See the&#xA;version attribute definition in HTML 4.01." name="version" />


### PR DESCRIPTION
- Additional `autocomplete` attribute values.
  - See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
- Add `dataset`, `contentEditable`, `isContentEditable`, `dir`, and `hidden` DOM properties.  Addresses Komodo/KomodoEdit#3115
- CSS 3 pseudo-classes.  Addresses Komodo/KomodoEdit#3451
-  Add `<ol>` type attribute.  Addresses Komodo/KomodoEdit#2385