### PR TITLE
Split View Updates

### DIFF
--- a/src/chrome/komodo/content/bindings/scintilla.p.xml
+++ b/src/chrome/komodo/content/bindings/scintilla.p.xml
@@ -312,7 +312,6 @@
             <field name="_ime">document.getAnonymousElementByAttribute(this, 'anonid', 'ime-input')</field>
 
             <field name="__scimoz_wrapper">null</field>
-            <field name="_scimoz">null</field>
             <property name="scimoz">
                 <getter><![CDATA[
                 if (!this.__scimoz_wrapper) {
@@ -752,7 +751,7 @@
                 // made to this instance. Bug 81293.
                 // Note: There should be no more calls to scimoz after this!
                 this.scimoz.markClosed();
-                this._scimoz = null;
+                this.__scimoz_wrapper = null;
             ]]></body>
             </method>
 

--- a/src/chrome/komodo/content/bindings/views-editor.p.xml
+++ b/src/chrome/komodo/content/bindings/views-editor.p.xml
@@ -1507,6 +1507,13 @@
         <body>
         <![CDATA[
         try {
+            // Don't allow save as for split view files.  Cheap fix to prevent changes from being applied to both old and new files.
+            if (this.koDoc.numScintillas > 1)
+            {
+                ko.dialogs.alert("You cannot use Save As on split view files.");
+                return false;
+            }
+
             if (typeof(directory)=='undefined') directory = null;
             this.makeCurrent();
             if (!this._validateEncoding()) return false;

--- a/src/chrome/komodo/content/bindings/views-editor.p.xml
+++ b/src/chrome/komodo/content/bindings/views-editor.p.xml
@@ -1507,13 +1507,6 @@
         <body>
         <![CDATA[
         try {
-            // Don't allow save as for split view files.  Cheap fix to prevent changes from being applied to both old and new files.
-            if (this.koDoc.numScintillas > 1)
-            {
-                ko.dialogs.alert("You cannot use Save As on split view files.");
-                return false;
-            }
-
             if (typeof(directory)=='undefined') directory = null;
             this.makeCurrent();
             if (!this._validateEncoding()) return false;

--- a/src/chrome/komodo/content/bindings/views-multi.xml
+++ b/src/chrome/komodo/content/bindings/views-multi.xml
@@ -339,6 +339,22 @@
         <parameter name="view"/>
         <body>
         <![CDATA[
+            // Don't allow multiple splits
+            if (view.koDoc.numScintillas > 1)
+            {
+                // Find existing view in other split view
+                var views = this.otherView.getViews();
+                for (var i = 0; i < views.length; i++)
+                {
+                    if (views[i].koDoc === view.koDoc)
+                    {
+                        this.lastFocused = this.otherView;
+                        this.setCurrentViewIndex(i);
+                        return;
+                    }
+                }
+                return;
+            }
             this.lastFocused = this.otherView;
             var item = view.item;
             // We save the state of the view

--- a/src/views/koDocument.py
+++ b/src/views/koDocument.py
@@ -175,7 +175,7 @@ class koDocumentBase(object):
         self._isDirty = 0     # boolean
         self.isUntitled = 1  # boolean
         self._views = [] # scintilla widget instances
-        self._updatedDocPointerViews = [] # scintilla widget instances where the docPointer was checked (e.g. for split-view)
+        self._updatedDocPointerViews = [] # scintilla widget instances where the docPointer was changed (e.g. for split-view)
         self._docPointer = None # scimoz.docPointer
         #XXX should get eol from prefs and/or from document content
         self._eol = eollib.EOL_PLATFORM

--- a/src/views/koDocument.py
+++ b/src/views/koDocument.py
@@ -175,6 +175,7 @@ class koDocumentBase(object):
         self._isDirty = 0     # boolean
         self.isUntitled = 1  # boolean
         self._views = [] # scintilla widget instances
+        self._updatedDocPointerViews = [] # scintilla widget instances where the docPointer was checked (e.g. for split-view)
         self._docPointer = None # scimoz.docPointer
         #XXX should get eol from prefs and/or from document content
         self._eol = eollib.EOL_PLATFORM
@@ -1796,6 +1797,7 @@ class koDocumentBase(object):
             self._docPointer = scimoz.docPointer
             scimoz.addRefDocument(self._docPointer)
         else:
+            self._updatedDocPointerViews.append(scintilla);
             scimoz.addRefDocument(self._docPointer)
             scimoz.docPointer = self._docPointer
             self.docSettingsMgr.register(xpself, scintilla)
@@ -1839,6 +1841,13 @@ class koDocumentBase(object):
             self._views.remove(scintilla)
             #if not self._views:
             #    self.docSettingsMgr = None
+
+            # Revert doc pointer if needed.  Resolves issue #231 where Save As on a split view updates both files.
+            if scintilla in self._updatedDocPointerViews:
+                self._updatedDocPointerViews.remove(scintilla);
+                newDocPointer = scimoz.createDocument()
+                scimoz.docPointer = newDocPointer
+                scimoz.releaseDocument(newDocPointer)
         except Exception, e:
             log.exception(e)
             raise


### PR DESCRIPTION
- Don't allow more than 2 splits.  Jump back to existing view.
  - I don't think there can be more than 2 split views, but let me know if it's possible and I'll remove this change.
- <strike>Cheap fix for Komodo/KomodoEdit#231</strike>
  - <strike>I couldn't figure out how split view works to sync the views.  This at least prevents the bug.  If you can easily explain how that syncing works, I can look into a better fix.</strike>
- Closes Komodo/KomodoEdit#231