### PR TITLE
Open Files UI Updates

### DIFF
--- a/src/modules/openfiles/content/openfiles.js
+++ b/src/modules/openfiles/content/openfiles.js
@@ -841,10 +841,20 @@ if (typeof ko.openfiles == 'undefined')
                                 ".file-title[value='"+editorView.title.replace(/'/g, "\\'")+"']");
             if (duplicates.length > 0)
             {
-                listItem.classList.add('duplicate-name');
+                // Ignore duplicates that are the exact same file (e.g. split view)
+                let nonExactDuplicates = [];
                 for (let dupe of duplicates)
                 {
-                    dupe.parentNode.classList.add('duplicate-name');
+                    if (dupe.parentNode.querySelector('.file-path').getAttribute('value') !== dirName)
+                        nonExactDuplicates.push(dupe);
+                }
+                if (nonExactDuplicates.length > 0)
+                {
+                    listItem.classList.add('duplicate-name');
+                    for (let dupe of nonExactDuplicates)
+                    {
+                        dupe.parentNode.classList.add('duplicate-name');
+                    }
                 }
             }
             

--- a/src/modules/openfiles/skin/openfiles.p.less
+++ b/src/modules/openfiles/skin/openfiles.p.less
@@ -11,6 +11,7 @@
         {
             margin-left: 3px;
             margin-top: 0px;
+            margin-right: 10px;
         }
         
         label.file-dirty
@@ -21,14 +22,13 @@
         
         label.file-path
         {
-            visibility: collapse;
-            opacity: 0.7;
+            opacity: 0;
             margin-top: 0px;
         }
         
         &.duplicate-name label.file-path
         {
-            visibility: visible;
+            opacity: 0.7;
         }
         
         image.file-icon


### PR DESCRIPTION
- Fix right aligned close icon.  Closes #3573
- Add a little space between filename and path or close X.
- Don't show path for "duplicate" of exact same file in split view.