### PR TITLE
Find Updates

### DIFF
--- a/src/chrome/komodo/content/find/embedded.p.xul
+++ b/src/chrome/komodo/content/find/embedded.p.xul
@@ -33,6 +33,7 @@
         onload="on_load()"
         onunload="on_unload()"
         onfocus="on_focus(event);"
+        onblur="on_blur();"
         orient="vertical">
 
     <script src="chrome://xtk/content/xtk.js" type="application/x-javascript;version=1.7"/>
@@ -49,6 +50,7 @@
       
     <keyset id="findKeys">
         <key keycode="VK_ESCAPE" modifiers="" oncommand="window.close();"/>
+        <key keycode="VK_RETURN" modifiers="shift" oncommand="handleReverseFindEnterKey();"/>
         <key keycode="VK_RETURN" oncommand="ko.dialogs.handleEnterKey();"/>
 <!-- #if PLATFORM != "darwin" -->
         <key key="d" modifiers="control" oncommand="search_in('document')" />


### PR DESCRIPTION
1. Disable access keys on window blur.  Closes #3706.
One downside to this is if people are using the access keys like Find Next while focused on the editor.  I'm not sure if people do that much.
2. Don't rebuild HTML with each open.
I removed this when running into an issue with an approach for 1 that I didn't go with, so I can add it back in if you want.  However, I didn't see why it was needed.  I see it was added in e8e1b2f9f5179be90715a3a4f94b7ff4e87f9b60 to deal with #669 and #710.  I was able to open Find multiple times and use Find All with no issues.
3. Add Shift-Enter for reverse search.