### PR TITLE
Don't Lowercase PHPDoc Types

### DIFF
--- a/src/udl/skel/PHP/pylib/lang_php.py
+++ b/src/udl/skel/PHP/pylib/lang_php.py
@@ -1619,7 +1619,7 @@ class PHPFunction:
                     if len(info) > 2:
                         description = " - " + " ".join(info[3:])
                     # <param_type> param_name - param_description (if exists)
-                    docblock_parsed += '<%s> %s %s\n' % (param_type.lower(), param_name, description, )
+                    docblock_parsed += '<%s> %s %s\n' % (param_type, param_name, description, )
                     
                 # @return entries
                 elif docstr.startswith("@return"):
@@ -1628,7 +1628,7 @@ class PHPFunction:
                     description = ""
                     if len(info) > 2: 
                         description = " - " + " ".join(info[2:])
-                    docblock_parsed += "Returns %s %s\n" % (return_type.lower(), description)
+                    docblock_parsed += "Returns %s %s\n" % (return_type, description)
                 
                 # Misc @ prefixed entries
                 elif docstr.startswith("@"):


### PR DESCRIPTION
The lowercase was adding in https://github.com/Komodo/KomodoEdit/pull/255.  I'm not positive, but I think that maybe lowercase was needed on https://github.com/Komodo/KomodoEdit/pull/255/files#diff-dc815a8023784357f18d19a1c5031ee2R1545, but added to the PHPDoc text too.

## Example of New Code
![image](https://user-images.githubusercontent.com/1426848/55685163-0689d580-5921-11e9-897d-722295ae1052.png)