### PR TITLE
CodeIntel Improvements

### DIFF
--- a/src/chrome/komodo/content/hyperlinks/gotodefinition.js
+++ b/src/chrome/komodo/content/hyperlinks/gotodefinition.js
@@ -198,8 +198,8 @@
     
             var currentPos = hyperlink.endPos;
             var style = scimoz.getStyleAt(currentPos);
-            var displayPath = view.koDoc.displayPath;
-            var wordUnderCursor = ko.interpolate.getWordUnderCursor(scimoz);
+            //var displayPath = view.koDoc.displayPath;
+            //var wordUnderCursor = ko.interpolate.getWordUnderCursor(scimoz);
     
             // We've told to update, but we may not need to:
             // If the position has not changed much and the the word under the

--- a/src/chrome/komodo/content/hyperlinks/gotodefinition.js
+++ b/src/chrome/komodo/content/hyperlinks/gotodefinition.js
@@ -184,6 +184,11 @@
         }
     }
 
+    this.GotoDefinitionHandler.prototype._lastDisplayPath = null;
+    this.GotoDefinitionHandler.prototype._lastCurrentPos = null;
+    this.GotoDefinitionHandler.prototype._lastWordUnderCursor = null;
+    this.GotoDefinitionHandler.prototype._lastStyle = null;
+
     /**
      * Function used to update the definiton information
      * @param hyperlink {ko.hyperlinks.Hyperlink} The hyperlink
@@ -198,26 +203,27 @@
     
             var currentPos = hyperlink.endPos;
             var style = scimoz.getStyleAt(currentPos);
-            //var displayPath = view.koDoc.displayPath;
-            //var wordUnderCursor = ko.interpolate.getWordUnderCursor(scimoz);
+            var displayPath = view.koDoc.displayPath;
+            var wordUnderCursor = ko.interpolate.getWordUnderCursor(scimoz);
     
             // We've told to update, but we may not need to:
             // If the position has not changed much and the the word under the
             // current position is the same as last time, if it is, do not
             // bother to update.
-            //if ((this._lastDisplayPath == displayPath) &&
-            //    (this._lastStyle == style) &&
-            //    ((currentPos <= (this._lastCurrentPos + 20)) &&
-            //     (currentPos >= (this._lastCurrentPos - 20)) &&
-            //     (wordUnderCursor == this._lastWordUnderCursor))) {
-            //    // The same place as current info, so nothing to update
-            //    return;
-            //}
+            if ((this._lastDisplayPath == displayPath) &&
+                (this._lastStyle == style) &&
+                ((currentPos <= (this._lastCurrentPos + 20)) &&
+                 (currentPos >= (this._lastCurrentPos - 20)) &&
+                 (wordUnderCursor == this._lastWordUnderCursor))) {
+                // The same place as current info, so nothing to update
+                return;
+            }
             //dump("Updating codehelper\n");
             // Remember this filename, position and style
-            //this._lastDisplayPath = displayPath;
-            //this._lastCurrentPos = currentPos;
-            //this._lastWordUnderCursor = wordUnderCursor;
+            this._lastDisplayPath = displayPath;
+            this._lastCurrentPos = currentPos;
+            this._lastWordUnderCursor = wordUnderCursor;
+            this._lastStyle = style;
     
             var langObj = view.koDoc.languageObj;
             var styleCount = new Object();

--- a/src/codeintel/lib/codeintel2/oop/controller.py
+++ b/src/codeintel/lib/codeintel2/oop/controller.py
@@ -37,6 +37,7 @@ class OOPEvalController(EvalController):
         if not loggerClass:
             loggerClass = logging.getLoggerClass()
         self.log = loggerClass("codeintel.evaluator")
+        self.log.setLevel(logging.WARN) # Only log warnings and worse
         self.log.manager = logging.Logger.manager
         self.log.propagate = False
         self.log.addHandler(self.log_hndlr)

--- a/src/codeintel/lib/codeintel2/tree_php.py
+++ b/src/codeintel/lib/codeintel2/tree_php.py
@@ -1185,6 +1185,10 @@ class PHPTreeEvaluator(TreeEvaluator):
                          first_token, scoperef)
                 return ([(elem, scoperef)], 1)
 
+        # Ignore keywords
+        if first_token in self.langintel.langinfo.keywords:
+            return (None, 1)
+
         while 1:
             self.log("_hits_from_first_part:: scoperef now %s:", scoperef)
             elem = self._elem_from_scoperef(scoperef)


### PR DESCRIPTION
- Comment out unused calltip variables
- Only log warning messages. Reduces excessively large error log messages
- Don't try to look up PHP keywords. They'll just result in an error

This addresses #3658 by preventing keyword lookups and limiting the messages logged.  However, I'm not sure if the issue should be closed in case @th3coop had plans to work on improving the underlying lookup.