### PR TITLE
Remove Empty MRU Warning

### DIFF
--- a/src/chrome/komodo/content/find/find2.p.js
+++ b/src/chrome/komodo/content/find/find2.p.js
@@ -641,10 +641,8 @@ function find_all() {
         var findFn = "findAllInFiles";
         if (_g_find_context.type == koIFindContext.FCT_IN_FILES) {
             ko.mru.addFromACTextbox(widgets.dirs);
-            if (widgets.includes.value)
-                ko.mru.addFromACTextbox(widgets.includes);
-            if (widgets.excludes.value)
-                ko.mru.addFromACTextbox(widgets.excludes);
+            ko.mru.addFromACTextbox(widgets.includes, true);
+            ko.mru.addFromACTextbox(widgets.excludes, true);
             gFindSvc.options.cwd = _g_find_context.cwd;
             _g_find_context.encodedFolders = gFindSvc.options.encodedFolders; // user may have changed since reset
         }

--- a/src/chrome/komodo/content/library/mru.js
+++ b/src/chrome/komodo/content/library/mru.js
@@ -167,10 +167,10 @@ this.maxEntries = function MRU_maxEntries(listPrefName)
 }
 
 
-this.add = function MRU_add(prefName, entry, caseSensitive)
+this.add = function MRU_add(prefName, entry, caseSensitive, allowBlank)
 {
     _log.info("MRU_add(prefName="+prefName+", entry="+entry+
-                ", caseSensitive="+caseSensitive+")");
+                ", caseSensitive="+caseSensitive+", allowBlank="+allowBlank+")");
 
     // Add the given "entry" (a string) to the given MRU (indentified by
     // the name of pref, "prefName", with which it is associated).
@@ -185,6 +185,11 @@ this.add = function MRU_add(prefName, entry, caseSensitive)
         errmsg = "MRU_add: invalid argument: prefName='"+prefName+"'";
         _log.error(errmsg);
         throw(errmsg);
+    }
+    if (!allowBlank && !entry) {
+        errmsg = "MRU_add: warning: no entry: prefName='"+prefName+
+                 "', entry='"+entry+"'";
+        _log.warn(errmsg)
     }
 
     var mruList = null;
@@ -327,7 +332,7 @@ this.addFromACTextbox = function MRU_addFromACTextbox(widget, allowBlank)
 
     _log.info("MRU_addFromACTextbox(widget): widget.value='"+widget.value+
                 "', prefName="+prefName);
-    ko.mru.add(prefName, widget.value, true);
+    ko.mru.add(prefName, widget.value, true, allowBlank);
 }
 
 

--- a/src/chrome/komodo/content/library/mru.js
+++ b/src/chrome/komodo/content/library/mru.js
@@ -186,11 +186,6 @@ this.add = function MRU_add(prefName, entry, caseSensitive)
         _log.error(errmsg);
         throw(errmsg);
     }
-    if (!entry) {
-        errmsg = "MRU_add: warning: no entry: prefName='"+prefName+
-                 "', entry='"+entry+"'";
-        _log.warn(errmsg)
-    }
 
     var mruList = null;
     if (prefSvc.prefs.hasPref(prefName)) {


### PR DESCRIPTION
When using find in project, the new Include filter results in the following error log message:
```
[WARNING] ko.mru: MRU_add: warning: no entry: prefName='find-includeFiletypesMru', entry=''
```
It's normal that an empty string should be saved there.