### PR TITLE
Jump to Code Fold

### DIFF
--- a/src/chrome/komodo/content/commandsOverlay.p.xul
+++ b/src/chrome/komodo/content/commandsOverlay.p.xul
@@ -703,6 +703,18 @@
             id="cmd_jumpToMatchingBrace" key="key_cmd_jumpToMatchingBrace"
             oncommand="ko.commands.doCommand('cmd_jumpToMatchingBrace')"
             desc="&sourceCodeJumpToMatchingBrace.desc;"/>
+        <command
+            id="cmd_jumpToParentFold" key="key_cmd_jumpToParentFold"
+            oncommand="ko.commands.doCommand('cmd_jumpToParentFold')"
+            desc="&sourceCodeJumpToParentFold.desc;"/>
+        <command
+            id="cmd_jumpToPreviousFold" key="key_cmd_jumpToPreviousFold"
+            oncommand="ko.commands.doCommand('cmd_jumpToPreviousFold')"
+            desc="&sourceCodeJumpToPreviousFold.desc;"/>
+        <command
+            id="cmd_jumpToNextFold" key="key_cmd_jumpToNextFold"
+            oncommand="ko.commands.doCommand('cmd_jumpToNextFold')"
+            desc="&sourceCodeJumpToNextFold.desc;"/>
 
 	<!-- emacs commands -->
         <command

--- a/src/chrome/komodo/content/komodo.p.xul
+++ b/src/chrome/komodo/content/komodo.p.xul
@@ -1141,6 +1141,18 @@
                                       id="menu_jumpToMatchingBrace"
                                       observes="cmd_jumpToMatchingBrace"
                                       />
+                            <menuitem label="&jumpToParentFold.label;"
+                                      id="menu_jumpToParentFold"
+                                      observes="cmd_jumpToParentFold"
+                                      />
+                            <menuitem label="&jumpToPreviousFold.label;"
+                                      id="menu_jumpToPreviousFold"
+                                      observes="cmd_jumpToPreviousFold"
+                                      />
+                            <menuitem label="&jumpToNextFold.label;"
+                                      id="menu_jumpToNextFold"
+                                      observes="cmd_jumpToNextFold"
+                                      />
                             <menuitem id="editor-jump-corresponding"
                                       label="&jumpToCorrespondingLineForDiffMode.label;"
                                       observes="cmd_jumpToCorrespondingLine"/>

--- a/src/chrome/komodo/locale/en-US/komodo.dtd
+++ b/src/chrome/komodo/locale/en-US/komodo.dtd
@@ -420,6 +420,9 @@
 <!ENTITY jumpToCorrespondingLine.label "Jump to corresponding line">
 <!ENTITY jumpToCorrespondingLineForDiffMode.label "Jump to Corresponding Line (for Diff mode)">
 <!ENTITY jumpToMatchingBrace.label "Jump to Matching Brace">
+<!ENTITY jumpToParentFold.label "Jump to Parent Fold">
+<!ENTITY jumpToPreviousFold.label "Jump to Previous Fold">
+<!ENTITY jumpToNextFold.label "Jump to Next Fold">
 <!ENTITY jumpToNextResult.label "Jump to next result">
 <!ENTITY jumpToNextResult.tooltiptext "Jump To Next Result">
 <!ENTITY jumpToPreviousResult.tooltiptext "Jump To Previous Result">
@@ -742,6 +745,9 @@
 <!ENTITY sourceCodeGoToDefinition.desc "Code: Go to Definition">
 <!ENTITY sourceCodeJumpToCorrespondingLine.desc "Code: Jump to corresponding line">
 <!ENTITY sourceCodeJumpToMatchingBrace.desc "Code: Jump to Matching Brace">
+<!ENTITY sourceCodeJumpToParentFold.desc "Code: Jump to Parent Fold">
+<!ENTITY sourceCodeJumpToPreviousFold.desc "Code: Jump to Previous Fold At the Same Level">
+<!ENTITY sourceCodeJumpToNextFold.desc "Code: Jump to Next Fold At the Same Level">
 <!ENTITY sourceCodeNextSyntaxErrorWarning.desc "Code: Next Syntax Error/Warning">
 <!ENTITY sourceCodeRunSyntaxCheck.desc "Code: Run Syntax Check">
 <!ENTITY sourceCodeSelectBlock.desc "Code: Select Block">

--- a/src/editor/koLanguageCommandHandler.p.py
+++ b/src/editor/koLanguageCommandHandler.p.py
@@ -1548,7 +1548,7 @@ class GenericCommandHandler:
         Jumps to the previous fold at the same level
         """
         sm = self._view.scimoz
-        initial_lineno = sm.lineFromPosition(sm.currentPos);
+        initial_lineno = sm.lineFromPosition(sm.currentPos)
         lineno = self._get_closest_fold_line(initial_lineno)
         if lineno is None:
             return
@@ -1572,7 +1572,7 @@ class GenericCommandHandler:
         Jumps to the next fold at the same level
         """
         sm = self._view.scimoz
-        initial_lineno = sm.lineFromPosition(sm.currentPos);
+        initial_lineno = sm.lineFromPosition(sm.currentPos)
         lineno = self._get_closest_fold_line(initial_lineno)
         if lineno is None:
             return
@@ -1594,7 +1594,7 @@ class GenericCommandHandler:
 
     def _do_cmd_jumpToParentFold(self):
         sm = self._view.scimoz
-        lineno = sm.lineFromPosition(sm.currentPos);
+        lineno = sm.lineFromPosition(sm.currentPos)
         fold_level = _fold_level(sm, lineno)
         if fold_level == sm.SC_FOLDLEVELBASE:
             return

--- a/src/editor/koLanguageCommandHandler.p.py
+++ b/src/editor/koLanguageCommandHandler.p.py
@@ -1555,54 +1555,53 @@ class GenericCommandHandler:
             lineno -= 1
         return lineno
 
-    def _do_cmd_jumpToPreviousFold(self):
+    def _get_closest_fold_line_level(self, lineno):
         """
-        Jumps to the previous fold at the same level
+        Get the fold level of the closest fold line per _get_closest_fold_line
+        """
+        lineno = self._get_closest_fold_line(lineno)
+        if lineno is None:
+            return None
+        return _fold_level(self._view.scimoz, lineno)
+
+    def _jump_to_sibling_fold(self, delta, end_lineno):
+        """
+        Jumps to the sibling fold at the same level
+        delta: -1 for prev; 1 for next
+        end_lineno: end line number
         """
         sm = self._view.scimoz
-        initial_lineno = sm.lineFromPosition(sm.currentPos)
-        lineno = self._get_closest_fold_line(initial_lineno)
-        if lineno is None:
+        lineno = sm.lineFromPosition(sm.currentPos)
+        if lineno == end_lineno:
             return
-        desired_fold_level = _fold_level(sm, lineno)
-        # Don't want the same fold
-        if lineno == initial_lineno:
-            lineno -= 1
+        desired_fold_level = self._get_closest_fold_line_level(lineno)
+        if desired_fold_level is None:
+            sm.gotoLine(end_lineno)
+            return
+        lineno += delta
 
-        # Search for previous fold at the same level
+        # Search for sibling fold at the same level
         while not _is_header_line(sm, lineno) or _fold_level(sm, lineno) > desired_fold_level:
-            if lineno == 0:
+            if lineno == end_lineno:
                 return
-            lineno -= 1
+            lineno += delta
 
         # If the current line is at the same fold level, go to it
         if _fold_level(sm, lineno) == desired_fold_level:
             sm.gotoLine(lineno)
+
+    def _do_cmd_jumpToPreviousFold(self):
+        """
+        Jumps to the previous fold at the same level
+        """
+        self._jump_to_sibling_fold(-1, 0)
 
     def _do_cmd_jumpToNextFold(self):
         """
         Jumps to the next fold at the same level
         """
         sm = self._view.scimoz
-        initial_lineno = sm.lineFromPosition(sm.currentPos)
-        lineno = self._get_closest_fold_line(initial_lineno)
-        if lineno is None:
-            return
-        desired_fold_level = _fold_level(sm, lineno)
-        # Don't want the same fold
-        if lineno <= initial_lineno:
-            lineno = initial_lineno + 1
-
-        # Search for next fold at the same level
-        line_count = sm.lineCount
-        while not _is_header_line(sm, lineno) or _fold_level(sm, lineno) > desired_fold_level:
-            if lineno > line_count:
-                return
-            lineno += 1
-
-        # If the current line is at the same fold level, go to it
-        if _fold_level(sm, lineno) == desired_fold_level:
-            sm.gotoLine(lineno)
+        self._jump_to_sibling_fold(1, sm.lineCount)
 
     def _do_cmd_jumpToParentFold(self):
         sm = self._view.scimoz


### PR DESCRIPTION
- This can be useful if you are in the middle of a function and want to jump up through the code to find parent conditionals and the parent function.  Also useful in large HTML blocks of text to get to the parent tag.
- Python doesn't have braces, so next and previous could be useful in place of the jump to matching brace function you can do in other languages.