### PR TITLE
Fix Split View Issues

### DIFF
--- a/src/chrome/komodo/content/bindings/views-multi.xml
+++ b/src/chrome/komodo/content/bindings/views-multi.xml
@@ -390,6 +390,30 @@
             if (typeof(index) == 'undefined' || index == null) index = -1;
         
             var doc = view.koDoc;
+
+            // Don't allow multiple splits, just close instead
+            if (doc.numScintillas > 1)
+            {
+                // Find existing view in other split view
+                var views = this.otherView.getViews();
+                var view2Idx = null;
+                for (var i = 0; i < views.length; i++)
+                {
+                    if (views[i].koDoc === doc)
+                    {
+                        view2Idx = i;
+                        break;
+                    }
+                }
+                view.close();
+                if (view2Idx !== null)
+                {
+                    this.lastFocused = this.otherView;
+                    this.setCurrentViewIndex(view2Idx);
+                }
+                return;
+            }
+
             var viewType = view.getAttribute('type');
             view.saveState();
             ko.views.manager.batchMode = true; // There are no view changes, so nothing really need to change here.

--- a/src/modules/openfiles/content/openfiles.js
+++ b/src/modules/openfiles/content/openfiles.js
@@ -822,7 +822,7 @@ if (typeof ko.openfiles == 'undefined')
             // Clone the template
             var listItem = template.fileItem.cloneNode(true);
             
-            var dirName = editorView.koDoc.file ? editorView.koDoc.file.dirName : '';
+            var dirName = editorView.koDoc && editorView.koDoc.file ? editorView.koDoc.file.dirName : '';
             var tooltip = "";
             if (["editor", "browser"].indexOf(editorView.getAttribute("type")) != -1)
                 tooltip = dirName == '' ? editorView.title : dirName;


### PR DESCRIPTION
1. Moving a file to a split with the same file resulted in exception.
2. Moving a file between tabs resulted in access to koDoc while null.