### PR TITLE
PHP CodeIntel Updates

### DIFF
--- a/src/codeintel/lib/codeintel2/oop/driver.py
+++ b/src/codeintel/lib/codeintel2/oop/driver.py
@@ -171,6 +171,7 @@ class Driver(threading.Thread):
 
         self.queue = collections.deque()
         self.queue_cv = threading.Condition()
+        self.pending_trg_from_pos_cnts = {}
         self.env = Environment(name="global",
                                send_fn=functools.partial(self.send, request=None))
 
@@ -531,6 +532,11 @@ class Driver(threading.Thread):
                 else:
                     log.debug("queuing request %r", request)
                     with self.queue_cv:
+                        if request.get("command") == "trg-from-pos" and request.path:
+                            if request.path in self.pending_trg_from_pos_cnts:
+                                self.pending_trg_from_pos_cnts[request.path] += 1
+                            else:
+                                self.pending_trg_from_pos_cnts[request.path] = 1
                         self.queue.appendleft(request)
                         self.queue_cv.notify()
             elif ch in "0123456789":
@@ -877,6 +883,20 @@ class CoreHandler(CommandHandler):
         except AttributeError:
             raise RequestFailure(message="No position given for trigger")
         buf = driver.get_buffer(request)
+
+        # If there's more than 1 pending requests, ignore until we get to the
+        # latest one. The others aren't important anymore
+        try:
+            if request.path in driver.pending_trg_from_pos_cnts:
+                if driver.pending_trg_from_pos_cnts[request.path] == 1:
+                    del driver.pending_trg_from_pos_cnts[request.path]
+                else:
+                    driver.pending_trg_from_pos_cnts[request.path] -= 1
+                    driver.send(trg=None)
+                    return
+        except:
+            log.error("Failed to check for pending requests")
+
         if "curr-pos" in request:
             trg = buf.preceding_trg_from_pos(pos, int(request["curr-pos"]))
         elif request.get("type", None) == "defn":

--- a/src/udl/skel/PHP/pylib/lang_php.py
+++ b/src/udl/skel/PHP/pylib/lang_php.py
@@ -1179,13 +1179,12 @@ class PHPLangIntel(CitadelLangIntel, ParenStyleCalltipIntelMixin,
 
             # Warn the user if there is a huge number of import dirs that
             # might slow down completion.
-            all_dirs = list(extra_dirs) + list(include_dirs)
-            num_import_dirs = len(all_dirs)
+            num_import_dirs = len(extra_dirs) + len(include_dirs)
             if num_import_dirs > 100:
                 msg = "This buffer is configured with %d %s import dirs: " \
                       "this may result in poor completion performance" % \
                       (num_import_dirs, self.lang)
-                self.mgr.report_message(msg, "\n".join(all_dirs))
+                self.mgr.report_message(msg, "\n".join(list(extra_dirs) + list(include_dirs)))
 
             # - cataloglib, stdlib
             catalog_selections = env.get_pref("codeintel_selected_catalogs")
@@ -1465,8 +1464,64 @@ def sortByLine(seq):
     return seq
 
 
+_phpdoc_primitive_types = [
+    "null",
+    "int", "integer",
+    "bool", "boolean",
+    "float", "double",
+    "string",
+    "array", "object",
+    "callable", "iterable",
+    "resource",
+    "mixed"
+]
+def _getFQNForType(varType, fileinfo, namespace):
+    """
+    Convert variable type (PHPDoc style) to FQN
+    """
+    # Handle int[]
+    if varType.endswith("[]"):
+        return _getFQNForTypePiece(varType[:-2], fileinfo, namespace) + "[]"
+    # Handle (...)
+    if varType.startswith("(") and varType.endswith(")"):
+        return _getFQNForTypePiece(varType[1:-1], fileinfo, namespace)
+    # Handle int|null
+    varTypes = varType.split("|");
+    rtn = ""
+    for varTypePiece in varTypes:
+        if rtn != "":
+            rtn += "|"
+        rtn += _getFQNForTypePiece(varTypePiece, fileinfo, namespace)
+    return rtn
+
+def _getFQNForTypePiece(varType, fileinfo, namespace):
+    """
+    Convert variable type (PHPDoc style) to FQN
+    """
+    if not "\\" in varType and not varType in _phpdoc_primitive_types:
+        imports_to_check = None
+        if namespace:
+            imports_to_check = namespace.includes
+        elif fileinfo:
+            imports_to_check = fileinfo.includes
+        if imports_to_check:
+            # Check for use statements
+            for use_import in imports_to_check:
+                if use_import.alias == varType or use_import.symbol == varType:
+                    varType = use_import.name + "\\" + use_import.symbol
+                    if varType[0] != "\\":
+                        varType = "\\" + varType
+                    break;
+            else:
+                # Add namespace if not found
+                if namespace:
+                    varType = namespace.name + "\\" + varType
+                    if varType[0] != "\\":
+                        varType = "\\" + varType
+    return varType
+
 class PHPArg:
-    def __init__(self, name, citdl=None, signature=None, default=None):
+    def __init__(self, name, citdl=None, signature=None, default=None, namespace=None, fileinfo=None):
         """Set details for a function argument"""
         self.name = name
         self.citdl = citdl
@@ -1478,6 +1533,8 @@ class PHPArg:
             else:
                 self.signature = "$%s" % (name, )
         self.default = default
+        self.namespace = namespace
+        self.fileinfo = fileinfo
 
     def __repr__(self):
         return self.signature
@@ -1491,7 +1548,10 @@ class PHPArg:
             self.signature = "%s %s" % (citdl, self.signature.split(" ", 1)[1])
 
     def toElementTree(self, cixelement, linestart=None):
-        cixarg = addCixArgument(cixelement, self.name, argtype=self.citdl)
+        argtype = self.citdl
+        if argtype:
+            argtype = _getFQNForType(argtype, self.fileinfo, self.namespace)
+        cixarg = addCixArgument(cixelement, self.name, argtype=argtype)
         if self.default:
             cixarg.attrib["default"] = self.default
         if linestart is not None:
@@ -1505,7 +1565,7 @@ class PHPVariable:
     _ignored_php_types = ("object", "mixed")
 
     def __init__(self, name, line, vartype='', attributes='', doc=None,
-                 fromPHPDoc=False, namespace=None):
+                 fromPHPDoc=False, namespace=None, fileinfo=None):
         self.name = name
         self.types = [(line, vartype, fromPHPDoc)]
         self.linestart = line
@@ -1516,6 +1576,8 @@ class PHPVariable:
         else:
             self.attributes = None
         self.doc = doc
+        self.fileinfo = fileinfo
+        self.namespace = namespace
         self.created_namespace = None
         if namespace:
             self.created_namespace = namespace.name
@@ -1554,6 +1616,8 @@ class PHPVariable:
                         vartype = None
                     break # only consider the first @var if name not given
 
+        if vartype:
+            vartype = _getFQNForType(vartype, self.fileinfo, self.namespace)
         if not vartype and self.types:
             d = {}
             max_count = 0
@@ -1584,8 +1648,8 @@ class PHPVariable:
         return cixelement
 
 class PHPConstant(PHPVariable):
-    def __init__(self, name, line, vartype=''):
-        PHPVariable.__init__(self, name, line, vartype)
+    def __init__(self, name, line, vartype='', fileinfo=None):
+        PHPVariable.__init__(self, name, line, vartype, fileinfo=fileinfo)
 
     def __repr__(self):
         return "constant %s line %s type %s\n"\
@@ -1599,7 +1663,8 @@ class PHPConstant(PHPVariable):
 class PHPFunction:
     def __init__(self, funcname, phpArgs, lineno, depth=0,
                  attributes=None, doc=None, classname='', classparent='',
-                 returnType=None, returnByRef=False):
+                 returnType=None, returnByRef=False,
+                 fileinfo=None, namespace=None):
         self.name = funcname
         self.args = phpArgs
         self.linestart = lineno
@@ -1607,6 +1672,8 @@ class PHPFunction:
         self.depth = depth
         self.classname = classname
         self.classparent = classparent
+        self.namespace = namespace
+        self.fileinfo = fileinfo
         self.returnType = returnType
         self.returnByRef = returnByRef
         self.variables = {} # all variables used in class
@@ -1643,10 +1710,11 @@ class PHPFunction:
                             phpArg.updateCitdl(argInfo[0])
                             break
                     else:
-                        self.args.append(PHPArg(argInfo[1], citdl=argInfo[0]))
+                        self.args.append(PHPArg(argInfo[1], citdl=argInfo[0], namespace=namespace, fileinfo=fileinfo))
             if docinfo[2]:
                 self.returnType = docinfo[2][0]
         if self.returnType:
+            # Update signature
             self.signature = '%s %s' % (self.returnType.lower(), self.signature, )
         self.signature += "("
         if self.args:
@@ -1733,7 +1801,7 @@ class PHPFunction:
             for phpArg in self.args:
                 phpArg.toElementTree(cixelement, self.linestart)
         if self.returnType:
-            addCixReturns(cixelement, self.returnType)
+            addCixReturns(cixelement, _getFQNForType(self.returnType, self.fileinfo, self.namespace))
         # Add a "this" and "self" member for class functions
         #if self.classname:
         #    createCixVariable(cixelement, "this", vartype=self.classname)
@@ -1819,7 +1887,7 @@ class PHPClass:
     _re_magic_method = re.compile(r'^\s*@method\s+((?P<citdl>[\w\\()|\[\]]+)\s+)?(?P<name>\w+)(\(\))?(?P<doc>.*?)$', re.M|re.U)
 
     def __init__(self, name, extends, lineno, depth, attributes=None,
-                 interfaces=None, doc=None):
+                 interfaces=None, doc=None, namespace=None, fileinfo=None):
         self.name = name
         self.extends = extends
         self.linestart = lineno
@@ -1848,7 +1916,7 @@ class PHPClass:
                 all_matches = re.findall(self._re_magic_property, self.doc)
                 for match in all_matches:
                     varname = match[4][1:]  # skip "$" in the name.
-                    v = PHPVariable(varname, lineno, resolveDocStringTypeToType(match[3]), doc=match[5])
+                    v = PHPVariable(varname, lineno, resolveDocStringTypeToType(match[3]), doc=match[5], fileinfo=fileinfo)
                     self.members[varname] = v
             if self.doc.find("@method") >= 0:
                 all_matches = re.findall(self._re_magic_method, self.doc)
@@ -1860,7 +1928,8 @@ class PHPClass:
                     fndoc = match[4]
                     phpArgs = []
                     fn = PHPFunction(fnname, phpArgs, lineno, depth=self.depth+1,
-                                     doc=fndoc, returnType=citdl)
+                                     doc=fndoc, returnType=citdl,
+                                     fileinfo=fileinfo, namespace=namespace)
                     self.functions[fnname] = fn
 
     def __repr__(self):
@@ -2250,7 +2319,9 @@ class PHPParser:
                                            classname=classname,
                                            classparent=extendsName,
                                            returnType=returnType,
-                                           returnByRef=returnByRef)
+                                           returnByRef=returnByRef,
+                                           fileinfo=self.fileinfo,
+                                           namespace=self.currentNamespace)
         if self.currentClass:
             self.currentClass.functions[self.currentFunction.name] = self.currentFunction
         elif self.currentNamespace:
@@ -2281,7 +2352,9 @@ class PHPParser:
                                          self.depth,
                                          attributes,
                                          interfaces,
-                                         doc=doc)
+                                         doc=doc,
+                                         fileinfo=self.fileinfo,
+                                         namespace=self.currentNamespace)
             toScope.classes[self.currentClass.name] = self.currentClass
             log.debug("%s: %s extends %s interfaces %s attributes %s on line %d in %s at depth %d\nDOCS: %s",
                      self.currentClass.cixtype,
@@ -2302,7 +2375,8 @@ class PHPParser:
                     self.currentFunction.variables[name] = PHPVariable(name,
                                                                        self.lineno,
                                                                        vartype,
-                                                                       doc=doc)
+                                                                       doc=doc,
+                                                                       fileinfo=self.fileinfo)
                 elif vartype:
                     log.debug("Adding type information for VAR: %r, vartype: %r",
                               name, vartype)
@@ -2314,7 +2388,8 @@ class PHPParser:
                 self.currentClass.members[name] = PHPVariable(name, self.lineno,
                                                               vartype,
                                                               attributes,
-                                                              doc=doc)
+                                                              doc=doc,
+                                                              fileinfo=self.fileinfo)
             elif vartype:
                 log.debug("Adding type information for CLASSMBR: %r, vartype: %r",
                           name, vartype)
@@ -2327,7 +2402,7 @@ class PHPParser:
             if phpConstant is None:
                 log.debug("CLASS CONST: %r", name)
                 self.currentClass.constants[name] = PHPConstant(name, self.lineno,
-                                                              vartype)
+                                                              vartype, fileinfo=self.fileinfo)
             elif vartype:
                 log.debug("Adding type information for CLASS CONST: %r, "
                           "vartype: %r", name, vartype)
@@ -2401,7 +2476,8 @@ class PHPParser:
                not self.currentFunction.hasArgumentWithName(name):
                 phpVariable = PHPVariable(name, self.lineno, vartype,
                                           attributes, doc=doc,
-                                          fromPHPDoc=fromPHPDoc)
+                                          fromPHPDoc=fromPHPDoc,
+                                          fileinfo=self.fileinfo)
                 self.currentFunction.variables[name] = phpVariable
                 already_existed = False
         elif self.currentClass and \
@@ -2420,7 +2496,8 @@ class PHPParser:
                 phpVariable = PHPVariable(name, self.lineno, vartype,
                                           attributes, doc=doc,
                                           fromPHPDoc=fromPHPDoc,
-                                          namespace=self.currentNamespace)
+                                          namespace=self.currentNamespace,
+                                          fileinfo=self.fileinfo)
                 self.fileinfo.variables[name] = phpVariable
                 already_existed = False
 
@@ -2446,7 +2523,7 @@ class PHPParser:
         if phpConstant is None:
             if vartype and isinstance(vartype, (list, tuple)):
                 vartype = ".".join(vartype)
-            toScope.constants[name] = PHPConstant(name, self.lineno, vartype)
+            toScope.constants[name] = PHPConstant(name, self.lineno, vartype, fileinfo=self.fileinfo)
 
     def addDefine(self, name, vartype='', doc=None):
         """Add a define at the global or namelisted scope level."""
@@ -2475,7 +2552,7 @@ class PHPParser:
         if phpConstant is None:
             if vartype and isinstance(vartype, (list, tuple)):
                 vartype = ".".join(vartype)
-            toScope.constants[const_name] = PHPConstant(const_name, self.lineno, vartype)
+            toScope.constants[const_name] = PHPConstant(const_name, self.lineno, vartype, fileinfo=self.fileinfo)
 
     def _parseOneArgument(self, styles, text):
         """Create a PHPArg object from the given text"""
@@ -2533,7 +2610,7 @@ class PHPParser:
         sig_parts += text[pos:]
         if name is not None:
             return PHPArg(name, citdl=citdl, signature="".join(sig_parts),
-                          default=default)
+                          default=default, namespace=self.currentNamespace, fileinfo=self.fileinfo)
 
     def _getArgumentsFromPos(self, styles, text, pos):
         """Return a list of PHPArg objects"""

--- a/src/udl/skel/PHP/pylib/lang_php.py
+++ b/src/udl/skel/PHP/pylib/lang_php.py
@@ -1504,7 +1504,7 @@ def _getFQNForType(varType, fileinfo, namespace):
     if varType.startswith("(") and varType.endswith(")"):
         return _getFQNForTypePiece(varType[1:-1], fileinfo, namespace)
     # Handle int|null
-    varTypes = varType.split("|");
+    varTypes = varType.split("|")
     rtn = ""
     for varTypePiece in varTypes:
         if rtn != "":
@@ -1529,7 +1529,7 @@ def _getFQNForTypePiece(varType, fileinfo, namespace):
                     varType = use_import.name + "\\" + use_import.symbol
                     if varType[0] != "\\":
                         varType = "\\" + varType
-                    break;
+                    break
             else:
                 # Add namespace if not found
                 if namespace:


### PR DESCRIPTION
- Use FQN for PHP types
- Skip outdated trg-from-pos requests.
  - For large files, trg-from-pos requests can back up as you type. I can't think of any reason why we'd need to process a request if we got a newer request for a new position.
- PSR4 updates
  - Allow filenames like MyClass.class.php
  - When doing PSR4 lookup, only concider paths that match namespace
  - Do not look at global scope with doing PSR4 lookups
- Use scandir for PHP import lookup.