### PR TITLE
Handle Object Member Completion on Array Index

### DIFF
--- a/src/udl/skel/PHP/pylib/lang_php.py
+++ b/src/udl/skel/PHP/pylib/lang_php.py
@@ -271,7 +271,8 @@ class PHPLangIntel(CitadelLangIntel, ParenStyleCalltipIntelMixin,
                     if prev_char == "-":
                         p, c, style = ac.getPrevPosCharStyle(ignore_styles=self.comment_styles_or_whitespace)
                         if style in (self.variable_style, self.identifier_style) or \
-                           (style == self.operator_style and c == ')'):
+                           (style == self.operator_style and c == ')') or \
+                           (style == self.operator_style and c == ']'):
                             return Trigger(lang, TRG_FORM_CPLN, "object-members",
                                            pos, implicit)
                         elif DEBUG:
@@ -758,7 +759,7 @@ class PHPLangIntel(CitadelLangIntel, ParenStyleCalltipIntelMixin,
                             print "stop at special stop-operator %d: %r" % (i, ch)
                         break
                 elif (ch in STOPOPS or ch in EXTRA_STOPOPS_PRECEDING_IDENT) and \
-                     (ch != ")" or (citdl_expr and citdl_expr[-1] != ".")):
+                     (ch not in ")]" or (citdl_expr and citdl_expr[-1] != "." and not (citdl_expr[-1] == "[" and citdl_expr[-2] == "]"))):
                     if ch == '$':
                         # This may not be the end of the road, given static
                         # variables are accessed through "Class::$static".


### PR DESCRIPTION
This handles completions on the commented out lines:
```php
/** @var LogicException[] */
$arr1d = [new LogicException()];
$idx = 0;
//$arr1d[0]->
//$arr1d[$idx]->

/** @var LogicException[] */
$arr2d = [[new LogicException()]];
//$arr2d[0][0]->
```