### PR TITLE
Fix Number of Tokens Consumed in PHP

### DIFF
--- a/src/codeintel/lib/codeintel2/tree_php.py
+++ b/src/codeintel/lib/codeintel2/tree_php.py
@@ -965,6 +965,7 @@ class PHPTreeEvaluator(TreeEvaluator):
                 try:
                     self.debug("_hit_from_citdl:: resolve %r on %r in %r",
                                remaining_tokens, *hit)
+                    nconsumed = 1
                     if remaining_tokens[0] == "()":
                         if not parent_lookup:
                             #TODO: impl this function


### PR DESCRIPTION
I introduced a bug in #3781.  I'm not exactly sure how to trigger it, but I saw this exception in the error log after all code intel stopped working.
```
[2019-12-17 09:33:49,457] [ERROR] codeintel.tree: Unexpected error with evaluator: 'taxCartItem.getSalesTaxOriginAddress' at SalesTaxHelper.class.php#1008
Traceback (most recent call last):
  File "/Applications/Komodo Edit 11.app/Contents/Resources/python/komodo/codeintel2/tree.py", line 321, in eval
    calltips = self.eval_calltips()
  File "/Applications/Komodo Edit 11.app/Contents/Resources/python/komodo/codeintel2/tree_php.py", line 358, in eval_calltips
    hit = self._hit_from_citdl(expr, start_scope)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/python/komodo/codeintel2/tree_php.py", line 946, in _hit_from_citdl
    hits = self._hit_from_citdl_remainining_tokens_hits(tokens[nconsumed:], first_part_hits, True)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/python/komodo/codeintel2/tree_php.py", line 988, in _hit_from_citdl_remainining_tokens_hits
    remaining_tokens = remaining_tokens[nconsumed:]
UnboundLocalError: local variable 'nconsumed' referenced before assignment
ERROR:xpcom:Unhandled exception calling 'int8 * run();'
Traceback (most recent call last):
  File "/Applications/Komodo Edit 11.app/Contents/Resources/python/xpcom/server/policy.py", line 303, in _CallMethod_
    return 0, func(*params)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/python/xpcom/components.py", line 237, in run
    self.result = self.fn(*self.args, **self.kwargs)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/components/koCodeIntel.py", line 1268, in handle
    callback(request, response)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/python/xpcom/components.py", line 268, in wrapperFn
    return fn(*args, **kwargs)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/components/koCodeIntel.py", line 1688, in callback
    handler.done()
  File "<XPCOMObject method 'done'>", line 3, in done
Exception: 2153185313 (NS_ERROR_XPC_JAVASCRIPT_ERROR_WITH_DETAILS)
[2019-12-17 09:47:51,740] [ERROR] codeintel.komodo.KoCodeIntelManager: Error reading data from codeintel
Traceback (most recent call last):
  File "/Applications/Komodo Edit 11.app/Contents/Resources/components/koCodeIntel.py", line 1190, in run
    self.handle(response)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/python/xpcom/components.py", line 263, in wrapperFn
    threadMgr.mainThread.dispatch(method, dispatch_flags)
  File "<XPCOMObject method 'dispatch'>", line 3, in dispatch
Exception: 2147500037 (NS_ERROR_FAILURE)
Exception in thread CodeIntel XPCOM Helper:
Traceback (most recent call last):
  File "/Applications/Komodo Edit 11.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python2.7/threading.py", line 808, in __bootstrap_inner
    self.run()
  File "/Applications/Komodo Edit 11.app/Contents/Resources/components/koCodeIntelXPCOMSupport.py", line 60, in run
    mgr.send(command="xpcom-connect", host=host, port=port)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/components/koCodeIntel.py", line 326, in send
    self.mgr.send(**kwargs)
  File "/Applications/Komodo Edit 11.app/Contents/Resources/components/koCodeIntel.py", line 1117, in send
    raise RuntimeError("Manager already shut down")
RuntimeError: Manager already shut down
```