### PR TITLE
Handle `@return static` in PHP

### DIFF
--- a/src/codeintel/lib/codeintel2/tree_php.py
+++ b/src/codeintel/lib/codeintel2/tree_php.py
@@ -979,7 +979,7 @@ class PHPTreeEvaluator(TreeEvaluator):
                             new_hit, nconsumed \
                                 = self._hit_from_getattr(remaining_tokens, elem, scoperef, ignore_attrs=parent_lookup)
                             ## if is function and return is in (this, ) return initial class
-                            if new_hit[0].get("ilk") == "function" and new_hit[0].get("returns") in ("this",):
+                            if new_hit[0].get("ilk") == "function" and new_hit[0].get("returns") in ("this", "static",):
                                 nconsumed = 2
                                 new_hit = hit
                                 if self.trg.form == TRG_FORM_CALLTIP and len(remaining_tokens) <= 1:


### PR DESCRIPTION
According to [PHPDoc](https://docs.phpdoc.org/latest/guides/types.html), `@return static` should return  "An object of the class where this value was consumed, if inherited it will represent the child class. (see late static binding in the PHP manual)."  This change handles that.

@th3coop, not sure if you want to merge this since CodeIntel is different from IDE.

Here's sample code:
```php
class Base
{
	public $baseVar1;
	public $baseVar2;

	/**
	 * @return static
	 */
	public function getInstance()
	{
		return new static();
	}
}

class Child extends Base
{
	public $childVar1;
	public $childVar2;
}

//$c = new Child();
$c = Child::getInstance();
$c-> // This should return 4 class variables, but only returns the Base class ones
```