### PR TITLE
Build with Docker: Image is missing the subversion package

### DIFF
--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y sudo git vim zip \
         libdbus-1-dev libdbus-glib-1-dev libasound2-dev libcurl4-openssl-dev \
         libiw-dev libxt-dev mesa-common-dev libpulse-dev libffi-dev python-setuptools \
         openssh-server python-dev libssl-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-        build-essential
+        build-essential subversion
 
 # Ubuntu 17.04 uses gcc 6, but we want gcc 4
 RUN apt-get remove -y gcc cpp g++ gcc-6 cpp-6 g++-6

--- a/util/docker/docklet
+++ b/util/docker/docklet
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-CURRENT_VERSION=12.10
-
 # Default docker image to use.
 if [ -z "$DOCKER_IMAGE_NAME" ]; then
     DOCKER_IMAGE_NAME="komodo"
@@ -155,14 +153,9 @@ function build-quick {
 }
 
 function run {
-    version=$1
-    if [ -z "${version}" ]
-    then
-        version=${CURRENT_VERSION}
-    fi
     cd $KOPATH
     # https://askubuntu.com/questions/1184774/some-applications-on-ubuntu-19-10-very-slow-to-start
-    dbus-launch --exit-with-session ./mozilla/build/moz3500-ko${version}/mozilla/ko-rel/dist/bin/komodo # Todo: auto-detect path
+    dbus-launch --exit-with-session ./mozilla/build/moz3500-ko12.10/mozilla/ko-rel/dist/bin/komodo # Todo: auto-detect path
     pkill -f "dbus-daemon --syslog --fork"
     pkill -f "dbus-launch --exit-with-session"
 }
@@ -235,12 +228,7 @@ while true; do
             shift
             ;;
         run)
-            version=""
-            if [ "$2" == "--version" ]; then
-                version=$3
-                shift 2
-            fi
-            run $version
+            run
             shift
             ;;
         image)

--- a/util/docker/docklet
+++ b/util/docker/docklet
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CURRENT_VERSION=12.10
+
 # Default docker image to use.
 if [ -z "$DOCKER_IMAGE_NAME" ]; then
     DOCKER_IMAGE_NAME="komodo"
@@ -153,9 +155,14 @@ function build-quick {
 }
 
 function run {
+    version=$1
+    if [ -z "${version}" ]
+    then
+        version=${CURRENT_VERSION}
+    fi
     cd $KOPATH
     # https://askubuntu.com/questions/1184774/some-applications-on-ubuntu-19-10-very-slow-to-start
-    dbus-launch --exit-with-session ./mozilla/build/moz3500-ko12.10/mozilla/ko-rel/dist/bin/komodo # Todo: auto-detect path
+    dbus-launch --exit-with-session ./mozilla/build/moz3500-ko${version}/mozilla/ko-rel/dist/bin/komodo # Todo: auto-detect path
     pkill -f "dbus-daemon --syslog --fork"
     pkill -f "dbus-launch --exit-with-session"
 }
@@ -228,7 +235,12 @@ while true; do
             shift
             ;;
         run)
-            run
+            version=""
+            if [ "$2" == "--version" ]; then
+                version=$3
+                shift 2
+            fi
+            run $version
             shift
             ;;
         image)


### PR DESCRIPTION
Hi,

I tried to build Komodo via Docker but the command _bk configure -V 10.10.0-devel_ failed, saying that svnversion was not found.
So, I added subversion to the Dockerfile.