### PR TITLE
Add argument "--version" to docklet run

### DIFF
--- a/util/docker/docklet
+++ b/util/docker/docklet
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CURRENT_VERSION=12.10
+
 # Default docker image to use.
 if [ -z "$DOCKER_IMAGE_NAME" ]; then
     DOCKER_IMAGE_NAME="komodo"
@@ -153,9 +155,14 @@ function build-quick {
 }
 
 function run {
+    version=$1
+    if [ -z "${version}" ]
+    then
+        version=${CURRENT_VERSION}
+    fi
     cd $KOPATH
     # https://askubuntu.com/questions/1184774/some-applications-on-ubuntu-19-10-very-slow-to-start
-    dbus-launch --exit-with-session ./mozilla/build/moz3500-ko12.10/mozilla/ko-rel/dist/bin/komodo # Todo: auto-detect path
+    dbus-launch --exit-with-session ./mozilla/build/moz3500-ko${version}/mozilla/ko-rel/dist/bin/komodo # Todo: auto-detect path
     pkill -f "dbus-daemon --syslog --fork"
     pkill -f "dbus-launch --exit-with-session"
 }
@@ -186,7 +193,7 @@ function help {
     echo "clean                     bk distclean"
     echo "build                     build Komodo"
     echo "build-quick               build quick Komodo"
-    echo "run                       run Komodo on host"
+    echo "run [--version VERSION]   run Komodo on host; version defaults to ${CURRENT_VERSION}"
     echo "status                    show container status"    
     echo "ssh                       ssh into container"
     echo "-h, --help                show brief help"
@@ -228,7 +235,12 @@ while true; do
             shift
             ;;
         run)
-            run
+            version=""
+            if [ "$2" == "--version" ]; then
+                version=$3
+                shift 2
+            fi
+            run $version
             shift
             ;;
         image)


### PR DESCRIPTION
Hi,

When building Komodo, users have to specify version for mozilla build and komodo build.
But when using Docker, there was no option to _docklet run_ to specify the version to run.